### PR TITLE
RUN-1057: Fix: Unable to save passwords kV version=1 hashicorp vault

### DIFF
--- a/docker/rundeck/remco/templates/rundeck-config-storage.properties
+++ b/docker/rundeck/remco/templates/rundeck-config-storage.properties
@@ -6,7 +6,11 @@ rundeck.storage.provider.{{index}}.type={% set type = printf("%s/type", provider
 rundeck.storage.provider.{{index}}.path={% set path = printf("%s/path", provider) %}{{ getv(path, "keys")}}
 rundeck.storage.provider.{{index}}.removePathPrefix={% set removepathprefix = printf("%s/removepathprefix", provider) %}{{ getv(removepathprefix, "false")}}
 
+{%- set prefix = getv(printf("%s/config/prefix", provider), "") %}
+{% if prefix %}
 rundeck.storage.provider.{{index}}.config.prefix={% set prefix = printf("%s/config/prefix", provider) %}{{ getv(prefix, "")}}
+{% endif %}
+
 rundeck.storage.provider.{{index}}.config.address={% set address = printf("%s/config/address", provider) %}{{ getv(address, "")}}
 rundeck.storage.provider.{{index}}.config.storageBehaviour={% set behaviour = printf("%s/config/behaviour", provider) %}{{ getv(behaviour, "rundeck")}}
 rundeck.storage.provider.{{index}}.config.secretBackend={% set secretbackend = printf("%s/config/secretbackend", provider) %}{{ getv(secretbackend, "secret")}}

--- a/docker/rundeck/remco/templates/rundeck-config-storage.properties
+++ b/docker/rundeck/remco/templates/rundeck-config-storage.properties
@@ -8,6 +8,7 @@ rundeck.storage.provider.{{index}}.removePathPrefix={% set removepathprefix = pr
 
 {%- set prefix = getv(printf("%s/config/prefix", provider), "") %}
 {% if prefix %}
+
 rundeck.storage.provider.{{index}}.config.prefix={% set prefix = printf("%s/config/prefix", provider) %}{{ getv(prefix, "")}}
 {% endif %}
 

--- a/docker/vault/run.sh
+++ b/docker/vault/run.sh
@@ -15,6 +15,12 @@ if (( $version > 1 )); then
     vault kv put secret/app/folder/another.secret test=hello
     vault kv put secret/app/folder/multiple2 name=admin password=admin server=rundeck
 
+    vault secrets enable -path=rundeck kv
+    vault kv put rundeck/simple.secret foo=world
+    vault kv put rundeck/multiples name=admin password=admin server=rundeck
+    vault kv put rundeck/folder/another.secret test=hello
+    vault kv put rundeck/folder/multiple2 name=admin password=admin server=rundeck
+
 else
     echo "Vault 0.x"
 

--- a/docker/vault/run.sh
+++ b/docker/vault/run.sh
@@ -15,7 +15,7 @@ if (( $version > 1 )); then
     vault kv put secret/app/folder/another.secret test=hello
     vault kv put secret/app/folder/multiple2 name=admin password=admin server=rundeck
 
-    vault secrets enable -path=rundeck kv
+    vault secrets enable -version=2 -path=rundeck kv
     vault kv put rundeck/simple.secret foo=world
     vault kv put rundeck/multiples name=admin password=admin server=rundeck
     vault kv put rundeck/folder/another.secret test=hello

--- a/src/main/java/io/github/valfadeev/rundeck/plugin/vault/VaultStoragePlugin.java
+++ b/src/main/java/io/github/valfadeev/rundeck/plugin/vault/VaultStoragePlugin.java
@@ -259,7 +259,7 @@ public class VaultStoragePlugin implements StoragePlugin {
     }
 
     public static String getVaultPath(String rawPath, String vaultSecretBackend, String vaultPrefix) {
-        String path= String.format("%s/%s/%s", vaultSecretBackend, vaultPrefix, rawPath);
+        String path= vaultPrefix != null && !vaultPrefix.equals("") ? String.format("%s/%s/%s", vaultSecretBackend, vaultPrefix, rawPath) : String.format("%s/%s", vaultSecretBackend, rawPath);
         return path;
     }
 


### PR DESCRIPTION
Fix: https://github.com/rundeck-plugins/vault-storage/issues/26

#### Problem
When `config.prefix` was an empty string, it was trying to insert resources on invalid paths 
eg: `rundeckSecretBackend//resource.exmpl` the `//` is taken as single `/` in kv v2 but it brings errors in kv v1 