### PR TITLE
RSE-198: Fix: Cannot navigate through key storage when using approle

### DIFF
--- a/src/main/java/io/github/valfadeev/rundeck/plugin/vault/VaultClientProvider.java
+++ b/src/main/java/io/github/valfadeev/rundeck/plugin/vault/VaultClientProvider.java
@@ -182,8 +182,7 @@ class VaultClientProvider {
 
                 } catch (VaultException e) {
                     throw new ConfigurationException(
-                            String.format("Encountered error while authenticating with %s",
-                                    vaultAuthBackend)
+                            String.format("Encountered error while authenticating with %s: %s", vaultAuthBackend, e.getLocalizedMessage())
                     );
                 }
                 break;

--- a/src/main/java/io/github/valfadeev/rundeck/plugin/vault/VaultStoragePlugin.java
+++ b/src/main/java/io/github/valfadeev/rundeck/plugin/vault/VaultStoragePlugin.java
@@ -269,8 +269,8 @@ public class VaultStoragePlugin implements StoragePlugin {
 
     protected void lookup(){
         try {
-            long ttl = getVaultClient().auth().lookupSelf().getTTL();
-            if (ttl <= guaranteedTokenValidity) {
+            LookupResponse lookupSelf = getVaultClient().auth().lookupSelf();
+            if (lookupSelf.getTTL() <= guaranteedTokenValidity || lookupSelf.getNumUses() < 0) {
                 loginVault(clientProvider);
             }
         } catch (VaultException e) {


### PR DESCRIPTION
Ticket: https://pagerduty.atlassian.net/browse/RSE-198

#### Problem

Steps to reproduce the behavior:

1. Install rundeck 4.6.1 on rhel8 or just use war in your local laptop “maybe macos”

2. In another instance or locally, install Hashicorp vault application 

3. On the vault side, see documentation to enable approle, don’t forget to add the correct policies:
```
# On cli
## Create 'rundeck-role' approle
vault write auth/approle/role/rundeck-role secret_id_ttl=0 secret_id_num_uses=0 token_num_uses=10 token_ttl=20m token_max_ttl=30m  

## Get approleId
vault read auth/approle/role/rundeck-role/role-id

## Get approleSecretId 
vault write -f auth/approle/role/rundeck-role/secret-id

# Vault gui: policies-> default-> edit policy -> New rule to default policy (full access to testing secret):
path "secret/*" {
    capabilities = ["create", "read", "update", "delete", "list"]
}
```
 

4. On your rundeck, use the setting for approle that you can see on the rundeck documentation but using a 2 level path (with at least 1 sub directory) for the prefix. Ex:
```
rundeck.storage.provider.2.type=vault-storage

rundeck.storage.provider.2.config.secretBackend=back1
rundeck.storage.provider.2.config.prefix=example/dev/rundeck
rundeck.storage.provider.2.path=keys/vault

rundeck.storage.provider.2.config.address=http://localhost:8080
rundeck.storage.provider.2.config.engineVersion=2
rundeck.storage.provider.2.config.storageBehaviour=vault

#auth
rundeck.storage.provider.2.config.authBackend=approle
rundeck.storage.provider.2.config.approleAuthMount=approle
rundeck.storage.provider.2.config.approleId=7e6e95ec-3c11-78eb-b5e6-1c2bc03299b3
rundeck.storage.provider.2.config.approleSecretId=5ca36ebd-2727-a2ab-15a0-4608d3158689
#timeouts
rundeck.storage.provider.2.config.maxRetries=500
rundeck.storage.provider.2.config.retryIntervalMilliseconds=2
rundeck.storage.provider.2.config.openTimeout=250
rundeck.storage.provider.2.config.readTimeout=250
```


5. Start rundeck and navigate inside key storage vault’s path.

6. Create a key in a subdirectory “<vaultPath>/subdir1/example.key" → Key gets created but also get a reading error.

7. Go to Keystorage again (through menu button), enter click on “<vaultPath>” directory and then click on previously created “subdir1“ → Server Error Shows up on screen and “{"errors":["permission denied"]}" in a service.log stacktrace

#### Solution
Check the number the available number of uses for the current token.