### PR TITLE
RUN-3601: CVE-2025-48924 Fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,10 @@ dependencies {
 
     //the compile dependency won't add the rundeck-core jar to the plugin contents
     implementation group: 'org.rundeck', name: 'rundeck-core', version: rundeckVersion
+    
+    // Add secure commons-lang3 to provide alternative to vulnerable commons-lang 2.6
+    implementation 'org.apache.commons:commons-lang3:3.18.0'
+    
     testImplementation(
             [group: 'junit', name: 'junit', version: '4.12', ext: 'jar'],
             [group: 'org.hamcrest', name: 'hamcrest-core', version: '1.3', ext: 'jar'],
@@ -66,6 +70,15 @@ dependencies {
     testImplementation "org.spockframework:spock-core:1.0-groovy-2.4"
     testImplementation "cglib:cglib-nodep:2.2.2"
 
+}
+
+configurations.all {
+    resolutionStrategy {
+        // Replace vulnerable commons-lang with secure commons-lang3
+        dependencySubstitution {
+            substitute module('commons-lang:commons-lang') using module('org.apache.commons:commons-lang3:3.18.0')
+        }
+    }
 }
 
 // task to copy plugin libs to output/lib dir


### PR DESCRIPTION
Mitigates CVE-2025-48924 by upgrading commons-lang to commons-lang3 3.18.0.

**Changes:**
- Added commons-lang3 3.18.0 dependency to build.gradle
- Configured dependency substitution to replace vulnerable commons-lang with secure commons-lang3
- Ensures all transitive dependencies use the secure version

**Security Impact:**
This change addresses the security vulnerability identified in CVE-2025-48924 by replacing the vulnerable commons-lang 2.x library with the secure commons-lang3 3.18.0 version.