### PR TITLE
Fix vault-storage integration tests: bump test container Java 11 → 17 for rundeck-cli

### DIFF
--- a/test/docker/dockers/rundeckvault/Dockerfile
+++ b/test/docker/dockers/rundeckvault/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get -y install rundeck-cli
 RUN \
  add-apt-repository -y ppa:openjdk-r/ppa  && \
  apt-get update && \
- apt-get install -y openjdk-11-jdk
+ apt-get install -y openjdk-17-jdk
 
 ENV USERNAME=rundeck \
     USER=rundeck \

--- a/test/docker/dockers/rundeckvault/tests/run-tests.sh
+++ b/test/docker/dockers/rundeckvault/tests/run-tests.sh
@@ -3,8 +3,8 @@
 #/ usage: dir
 set -euo pipefail
 
-export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
-export PATH=/usr/lib/jvm/java-11-openjdk-amd64/jre/bin:$PATH
+export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+export PATH=/usr/lib/jvm/java-17-openjdk-amd64/bin:$PATH
 
 IFS=$'\n\t'
 readonly ARGS=("$@")

--- a/test/docker/dockers/rundeckvault/tests/run.sh
+++ b/test/docker/dockers/rundeckvault/tests/run.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 set -e
-export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
-export PATH=/usr/lib/jvm/java-11-openjdk-amd64/jre/bin:$PATH
+export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+export PATH=/usr/lib/jvm/java-17-openjdk-amd64/bin:$PATH
 
 TEST_DIR=$1
 TEST_SCRIPT=${2:-/tests/run-tests.sh}


### PR DESCRIPTION
## Summary
CI builds on `main` were failing the vault-storage integration test suite with:
```
Error: LinkageError occurred while loading main class org.rundeck.client.tool.Main
java.lang.UnsupportedClassVersionError: org/rundeck/client/tool/Main has been compiled by
a more recent version of the Java Runtime (class file version 61.0), this version of the
Java Runtime only recognizes class file versions up to 55.0
```

The test Dockerfile installs `rundeck-cli` from the packagecloud repo, which always pulls
the latest package. That package is now built targeting Java 17 (class file version 61),
but the test container and scripts pinned `JAVA_HOME`/`PATH` to `openjdk-11` (class file
version 55), so the CLI could no longer run. This is unrelated to the recent rundeck-core
CVE bump — it's the same failure mode fixed previously in this repo when the CLI moved
from Java 8 to Java 11 (commit `1a81a14`).

- Install `openjdk-17-jdk` instead of `openjdk-11-jdk` in `test/docker/dockers/rundeckvault/Dockerfile`
- Point `JAVA_HOME`/`PATH` at `java-17-openjdk-amd64` in `tests/run.sh` and `tests/run-tests.sh`
- Fix `PATH` to point at `.../bin` instead of the nonexistent `.../jre/bin` (JDK 9+ dropped the separate `jre` directory; this stale path was carried over from the Java 8 era)

All three `docker-compose-*vault*.yml` test configs share this Docker build context, so this covers each of them.

## Test plan
- [ ] CI vault-storage integration test job passes on this branch