### PR TITLE
Fix vault-storage plugin jar not copied into docker test image

### DIFF
--- a/run-docker-vault-tests.sh
+++ b/run-docker-vault-tests.sh
@@ -33,12 +33,13 @@ check_args(){
 copy_jar(){
 	local FARGS=("$@")
 	local DIR=${FARGS[0]}
-	local -a VERS=( $( rd_get_plugin_version ) )
-	local JAR=$(basename "$PWD")-*.jar
-	local buildJar=$PWD/build/libs/$JAR
-	test -f $buildJar || die "Jar file not found $buildJar"
+	local buildJar
+	buildJar=$(find "$PWD/build/libs" -maxdepth 1 -name "$(basename "$PWD")-*.jar" \
+		-not -name "*-sources.jar" -not -name "*-javadoc.jar" | sort | tail -1)
+	test -n "$buildJar" && test -f "$buildJar" || die "Jar file not found in $PWD/build/libs"
+	local JAR=$(basename "$buildJar")
 	mkdir -p $DIR
-	cp $buildJar $DIR/dockers/rundeckvault/plugins
+	cp "$buildJar" $DIR/dockers/rundeckvault/plugins
 	echo $DIR/dockers/rundeckvault/plugins/$JAR
 }
 run_tests(){
@@ -54,7 +55,8 @@ run_tests(){
 run_docker_test(){
 	local FARGS=("$@")
 	local DIR=${FARGS[0]}
-	local launcherJar=$( copy_jar $DIR ) || die "Failed to copy jar"
+	local launcherJar
+	launcherJar=$( copy_jar $DIR ) || die "Failed to copy jar"
 	echo "Testing: $launcherJar"
 	run_tests $DIR
 }


### PR DESCRIPTION
## Summary
After merging #96 (Java 11 → 17 fix for the CLI in the vault-storage docker test container), the integration tests progressed further and hit a new failure: the running Rundeck instance couldn't load the plugin at all —
```
Error: Storage Plugin named "vault-storage" could not be loaded
...
Failed to start execution: java.lang.IllegalArgumentException: Storage Plugin named "vault-storage" could not be loaded
```

This is a pre-existing bug in `run-docker-vault-tests.sh` that was previously masked because the pipeline died earlier (at the Java version mismatch fixed in #96).

**Root cause:** `copy_jar()` selected the plugin jar with an unquoted glob `vault-storage-*.jar`. Gradle's `build/libs/` contains three matches per build — the main jar, `-sources.jar`, and `-javadoc.jar` — so `test -f $buildJar` expanded to 3 arguments and failed:
```
run-docker-vault-tests.sh: line 39: test: too many arguments
Jar file not found ...
```
That failure should have aborted the script, but a second bug masked it: `local launcherJar=$(copy_jar $DIR) || die ...` — combining `local` with a command substitution always returns `local`'s own exit status, never the substitution's, so `|| die` never fired. The script silently continued without ever copying the plugin jar into `test/docker/dockers/rundeckvault/plugins/`, so the Docker image was built with no plugin at all.

## Changes
- `copy_jar()` now uses `find ... -not -name "*-sources.jar" -not -name "*-javadoc.jar"` to select only the main plugin jar.
- Split `local launcherJar=$(...)` into a separate declaration and assignment so a real failure now correctly propagates to `|| die` instead of being swallowed.

## Test plan
- [ ] CI vault-storage integration test job passes on this branch
- [x] Verified the jar-selection `find` command picks the correct single jar locally (excludes sources/javadoc)
- [x] `bash -n run-docker-vault-tests.sh` passes