### PR TITLE
[RUN-4788] Add certRoleName config option for Vault TLS cert auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@ rundeck.storage.provider.[index].config.authNamespace=namespace
 rundeck.storage.provider.[index].config.certAuthMount=mount-name
 ```
 
+* **certRoleName**: Cert Role Name (Optional). The name of the certificate role to authenticate against, sent as the `name` parameter in the cert auth login request ([Vault cert auth API](https://developer.hashicorp.com/vault/api-docs/auth/cert#login-with-tls-certificate-method)). Required by Vault deployments that register multiple certificate roles under the same auth mount and need the role name to be specified explicitly. If not set, Vault selects a role by matching the presented certificate (previous behavior, unaffected).
+```
+rundeck.storage.provider.[index].config.certRoleName=my-certificate-role-name
+```
+
 * **keyStoreFile**: Key store file
 A Java keystore, containing a client certificate that's registered with Vault's TLS Certificate auth backend.
 
@@ -270,12 +275,14 @@ rundeck.storage.provider.1.config.authBackend=cert
 rundeck.storage.provider.1.config.secretBackend=kv
 rundeck.storage.provider.1.config.engineVersion=2
 rundeck.storage.provider.1.config.certAuthMount=tls-auth
+rundeck.storage.provider.1.config.certRoleName=my-certificate-role-name
 rundeck.storage.provider.1.config.keyStoreFile=$KEYSTORE_FILE
 rundeck.storage.provider.1.config.keyStoreFilePassword=$KEYSTORE_PASSWORD
 rundeck.storage.provider.1.config.trustStoreFile=$TRUSTSTORE_FILE
 rundeck.storage.provider.1.config.truststoreFilePassword=$TRUSTSTORE_PASSWORD
 rundeck.storage.provider.1.config.validateSsl=true
 ```
+`certRoleName` is optional — omit it to keep the previous behavior of letting Vault pick the role by matching the certificate.
 ## Vault API versions
 
 Since version 1.3.1, this plugin can work with `kV Secrets Engine - Version 2`. 

--- a/src/main/java/io/github/valfadeev/rundeck/plugin/vault/ConfigOptions.java
+++ b/src/main/java/io/github/valfadeev/rundeck/plugin/vault/ConfigOptions.java
@@ -31,5 +31,6 @@ class ConfigOptions {
     static final String VAULT_USE_VAULT_METADATA_TIMESTAMPS = "useVaultMetadataTimestamps";
     static final String VAULT_AUTH_NAMESPACE = "authNamespace";
     static final String VAULT_CERT_AUTH_MOUNT = "certAuthMount";
+    static final String VAULT_CERT_ROLE_NAME = "certRoleName";
 
 }

--- a/src/main/java/io/github/valfadeev/rundeck/plugin/vault/VaultClientProvider.java
+++ b/src/main/java/io/github/valfadeev/rundeck/plugin/vault/VaultClientProvider.java
@@ -426,6 +426,14 @@ class VaultClientProvider {
                     restResponse.getStatus());
         }
 
+        // Same MIME-type check Auth.loginByCert()/loginByAppRole() do internally: surfaces a clear
+        // error for a 200 with an unexpected body (e.g. a proxy in front of Vault) instead of
+        // AuthResponse silently swallowing the JSON parse failure and returning a null token.
+        final String mimeType = restResponse.getMimeType() == null ? "null" : restResponse.getMimeType();
+        if (!mimeType.equals("application/json")) {
+            throw new VaultException("Vault responded with MIME type: " + mimeType, restResponse.getStatus());
+        }
+
         return new AuthResponse(restResponse, 0).getAuthClientToken();
     }
 }

--- a/src/main/java/io/github/valfadeev/rundeck/plugin/vault/VaultClientProvider.java
+++ b/src/main/java/io/github/valfadeev/rundeck/plugin/vault/VaultClientProvider.java
@@ -3,6 +3,7 @@ package io.github.valfadeev.rundeck.plugin.vault;
 import java.io.File;
 import java.io.FileInputStream;
 import java.net.http.HttpClient;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyStore;
 import java.util.Properties;
 
@@ -11,6 +12,11 @@ import io.github.jopenlibs.vault.Vault;
 import io.github.jopenlibs.vault.VaultConfig;
 import io.github.jopenlibs.vault.VaultException;
 import io.github.jopenlibs.vault.api.Auth;
+import io.github.jopenlibs.vault.json.Json;
+import io.github.jopenlibs.vault.response.AuthResponse;
+import io.github.jopenlibs.vault.rest.Rest;
+import io.github.jopenlibs.vault.rest.RestException;
+import io.github.jopenlibs.vault.rest.RestResponse;
 import com.dtolabs.rundeck.core.plugins.configuration.ConfigurationException;
 
 import static io.github.valfadeev.rundeck.plugin.vault.ConfigOptions.*;
@@ -334,8 +340,14 @@ class VaultClientProvider {
                 LOG.debug("[vault] auth=CERT");
                 final String configured = configuration.getProperty(VAULT_CERT_AUTH_MOUNT);
                 final String mount = (configured == null || configured.isEmpty()) ? "cert" : configured;
+                final String certRoleName = configuration.getProperty(VAULT_CERT_ROLE_NAME);
                 try {
-                    authToken = vaultAuth.loginByCert(mount).getAuthClientToken();
+                    if (certRoleName != null && !certRoleName.isEmpty()) {
+                        LOG.debug("[vault] Cert login with role name at mount '{}'", mount);
+                        authToken = loginByCertWithRoleName(vaultAuthConfig, mount, certRoleName);
+                    } else {
+                        authToken = vaultAuth.loginByCert(mount).getAuthClientToken();
+                    }
 
                 } catch (VaultException e) {
                     LOG.debug("[vault] Cert login failed: {}", e.getMessage(), e);
@@ -353,5 +365,45 @@ class VaultClientProvider {
 
         }
         return authToken;
+    }
+
+    /**
+     * Logs in via Vault's TLS Certificate auth backend, pinning the login to a specific
+     * certificate role by sending the optional {@code name} field Vault's cert auth API accepts
+     * (see https://developer.hashicorp.com/vault/api-docs/auth/cert#login-with-tls-certificate-method).
+     * <p>
+     * {@link Auth#loginByCert(String)} in vault-java-driver does not expose this parameter, so this
+     * issues the {@code POST /v1/auth/<mount>/login} request directly (mirroring what the driver does
+     * internally, e.g. for {@code loginByAppRole}), reusing the already-configured TLS material and
+     * shared {@link HttpClient} from {@code vaultConfig}.
+     */
+    private String loginByCertWithRoleName(VaultConfig vaultConfig, String mount, String roleName)
+            throws VaultException {
+        final String requestJson = Json.object().add("name", roleName).toString();
+
+        final RestResponse restResponse;
+        try {
+            restResponse = new Rest(vaultConfig.getHttpClient())
+                    .url(vaultConfig.getAddress() + "/v1/auth/" + mount + "/login")
+                    .header("X-Vault-Namespace", vaultConfig.getNameSpace())
+                    .header("X-Vault-Request", "true")
+                    .body(requestJson.getBytes(StandardCharsets.UTF_8))
+                    .connectTimeoutSeconds(vaultConfig.getOpenTimeout())
+                    .readTimeoutSeconds(vaultConfig.getReadTimeout())
+                    .sslVerification(vaultConfig.getSslConfig().isVerify())
+                    .sslContext(vaultConfig.getSslConfig().getSslContext())
+                    .post();
+        } catch (RestException e) {
+            throw new VaultException(e);
+        }
+
+        if (restResponse.getStatus() != 200) {
+            throw new VaultException(
+                    "Vault responded with HTTP status code: " + restResponse.getStatus()
+                            + "\nResponse body: " + new String(restResponse.getBody(), StandardCharsets.UTF_8),
+                    restResponse.getStatus());
+        }
+
+        return new AuthResponse(restResponse, 0).getAuthClientToken();
     }
 }

--- a/src/main/java/io/github/valfadeev/rundeck/plugin/vault/VaultClientProvider.java
+++ b/src/main/java/io/github/valfadeev/rundeck/plugin/vault/VaultClientProvider.java
@@ -381,18 +381,40 @@ class VaultClientProvider {
             throws VaultException {
         final String requestJson = Json.object().add("name", roleName).toString();
 
+        // Same defensive guards as VaultKvMetadataReader.readSecretTimestamps, for consistency:
+        // trim a trailing '/' from the address, and only set namespace/sslContext when present.
+        // None of these are live bugs against vault-java-driver 6.2.2 today -- VaultConfig.address()
+        // already strips a trailing slash, and Rest already no-ops on a null/empty header value or a
+        // null sslContext -- but guarding explicitly here doesn't rely on those driver internals.
+        String address = vaultConfig.getAddress();
+        if (address != null && address.endsWith("/")) {
+            address = address.substring(0, address.length() - 1);
+        }
+
+        final SslConfig sslConfig = vaultConfig.getSslConfig();
+
         final RestResponse restResponse;
         try {
-            restResponse = new Rest(vaultConfig.getHttpClient())
-                    .url(vaultConfig.getAddress() + "/v1/auth/" + mount + "/login")
-                    .header("X-Vault-Namespace", vaultConfig.getNameSpace())
+            Rest rest = new Rest(vaultConfig.getHttpClient())
+                    .url(address + "/v1/auth/" + mount + "/login")
                     .header("X-Vault-Request", "true")
                     .body(requestJson.getBytes(StandardCharsets.UTF_8))
                     .connectTimeoutSeconds(vaultConfig.getOpenTimeout())
-                    .readTimeoutSeconds(vaultConfig.getReadTimeout())
-                    .sslVerification(vaultConfig.getSslConfig().isVerify())
-                    .sslContext(vaultConfig.getSslConfig().getSslContext())
-                    .post();
+                    .readTimeoutSeconds(vaultConfig.getReadTimeout());
+
+            final String nameSpace = vaultConfig.getNameSpace();
+            if (nameSpace != null && !nameSpace.isEmpty()) {
+                rest.header("X-Vault-Namespace", nameSpace);
+            }
+
+            if (sslConfig != null) {
+                rest.sslVerification(sslConfig.isVerify());
+                if (sslConfig.getSslContext() != null) {
+                    rest.sslContext(sslConfig.getSslContext());
+                }
+            }
+
+            restResponse = rest.post();
         } catch (RestException e) {
             throw new VaultException(e);
         }

--- a/src/main/java/io/github/valfadeev/rundeck/plugin/vault/VaultStoragePlugin.java
+++ b/src/main/java/io/github/valfadeev/rundeck/plugin/vault/VaultStoragePlugin.java
@@ -108,6 +108,14 @@ public class VaultStoragePlugin implements StoragePlugin {
     @RenderingOption(key = StringRenderingConstants.GROUP_NAME, value = "Authentication")
     String certAuthMount;
 
+    @PluginProperty(title = "Cert Role Name",
+            description = "Optional. The name of the certificate role to authenticate against, sent as the "
+                    + "'name' parameter in the cert auth login request. Required by Vault deployments that "
+                    + "register multiple certificate roles under the same auth mount. If not set, Vault selects "
+                    + "a role by matching the presented certificate, preserving prior behavior.")
+    @RenderingOption(key = StringRenderingConstants.GROUP_NAME, value = "Authentication")
+    String certRoleName;
+
     @PluginProperty(title = "Key store file", description = "A Java keystore, containing a client certificate " + "that's registered with Vault's TLS Certificate auth backend.")
     @RenderingOption(key = StringRenderingConstants.GROUP_NAME, value = "Authentication")
     String keyStoreFile;
@@ -249,6 +257,9 @@ public class VaultStoragePlugin implements StoragePlugin {
             }
             if (certAuthMount != null) {
                 properties.setProperty(VAULT_CERT_AUTH_MOUNT, certAuthMount);
+            }
+            if (certRoleName != null) {
+                properties.setProperty(VAULT_CERT_ROLE_NAME, certRoleName);
             }
             if(pemFile != null){
                 properties.setProperty(VAULT_PEM_FILE, pemFile);

--- a/src/test/java/io/github/valfadeev/rundeck/plugin/vault/VaultClientProviderTest.java
+++ b/src/test/java/io/github/valfadeev/rundeck/plugin/vault/VaultClientProviderTest.java
@@ -1,8 +1,12 @@
 package io.github.valfadeev.rundeck.plugin.vault;
 
 import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 
+import com.sun.net.httpserver.HttpServer;
+import io.github.jopenlibs.vault.Vault;
 import io.github.jopenlibs.vault.VaultConfig;
 import org.junit.Test;
 
@@ -28,5 +32,100 @@ public class VaultClientProviderTest {
         assertThat(config.getSslConfig().isVerify(), is(false));
         assertThat(config.getOpenTimeout(), is(5));
         assertThat(config.getReadTimeout(), is(20));
+    }
+
+    /**
+     * When {@code certRoleName} is configured, the cert auth login request must carry the
+     * Vault cert auth API's optional {@code name} parameter (see
+     * https://developer.hashicorp.com/vault/api-docs/auth/cert#login-with-tls-certificate-method)
+     * so Vault deployments requiring an explicit certificate role can be authenticated against.
+     */
+    @Test
+    public void certAuthWithRoleNameSendsNameInLoginRequestBody() throws Exception {
+        final String[] capturedPath = new String[1];
+        final String[] capturedBody = new String[1];
+
+        HttpServer server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/v1/auth/tls-auth/login", exchange -> {
+            capturedPath[0] = exchange.getRequestURI().getPath();
+            capturedBody[0] = new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
+
+            byte[] response = ("{\"auth\":{\"client_token\":\"s.faketoken\",\"renewable\":false,"
+                    + "\"lease_duration\":0,\"policies\":[\"default\"]},\"renewable\":false}")
+                    .getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, response.length);
+            exchange.getResponseBody().write(response);
+            exchange.close();
+        });
+        server.start();
+
+        try {
+            Properties configuration = new Properties();
+            configuration.setProperty("address", "http://localhost:" + server.getAddress().getPort());
+            configuration.setProperty("authBackend", "cert");
+            configuration.setProperty("certAuthMount", "tls-auth");
+            configuration.setProperty("certRoleName", "app-01693-lseg-enterprise-rundeck");
+            configuration.setProperty("validateSsl", "false");
+            configuration.setProperty("maxRetries", "0");
+            configuration.setProperty("retryIntervalMilliseconds", "0");
+            configuration.setProperty("openTimeout", "5");
+            configuration.setProperty("readTimeout", "5");
+            configuration.setProperty("engineVersion", "1");
+
+            Vault vault = new VaultClientProvider(configuration).getVaultClient();
+
+            assertThat(vault, is(notNullValue()));
+            assertThat(capturedPath[0], is("/v1/auth/tls-auth/login"));
+            assertThat(capturedBody[0], is("{\"name\":\"app-01693-lseg-enterprise-rundeck\"}"));
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    /**
+     * Backward compatibility: when {@code certRoleName} is not set, no request body is sent at
+     * all (the plugin falls back to the vault-java-driver's own {@code loginByCert}, which relies
+     * solely on the mTLS handshake to identify the client).
+     */
+    @Test
+    public void certAuthWithoutRoleNameSendsNoBody() throws Exception {
+        final String[] capturedBody = new String[1];
+        final boolean[] requestReceived = new boolean[1];
+
+        HttpServer server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/v1/auth/cert/login", exchange -> {
+            requestReceived[0] = true;
+            capturedBody[0] = new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
+
+            byte[] response = ("{\"auth\":{\"client_token\":\"s.faketoken\",\"renewable\":false,"
+                    + "\"lease_duration\":0,\"policies\":[\"default\"]},\"renewable\":false}")
+                    .getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, response.length);
+            exchange.getResponseBody().write(response);
+            exchange.close();
+        });
+        server.start();
+
+        try {
+            Properties configuration = new Properties();
+            configuration.setProperty("address", "http://localhost:" + server.getAddress().getPort());
+            configuration.setProperty("authBackend", "cert");
+            configuration.setProperty("validateSsl", "false");
+            configuration.setProperty("maxRetries", "0");
+            configuration.setProperty("retryIntervalMilliseconds", "0");
+            configuration.setProperty("openTimeout", "5");
+            configuration.setProperty("readTimeout", "5");
+            configuration.setProperty("engineVersion", "1");
+
+            Vault vault = new VaultClientProvider(configuration).getVaultClient();
+
+            assertThat(vault, is(notNullValue()));
+            assertThat(requestReceived[0], is(true));
+            assertThat(capturedBody[0], is(""));
+        } finally {
+            server.stop(0);
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds an optional `certRoleName` config property to the Vault Storage plugin so customers can authenticate with Vault deployments whose TLS cert auth mount requires an explicit certificate role name.

## Problem

The `vault-java-driver`'s `Auth.loginByCert(mount)` sends a bare `POST /v1/auth/<mount>/login` with **no request body** — client identity comes only from the mTLS handshake. Vault's cert auth API supports an optional `name` parameter to pin the login to a specific configured certificate role, but the driver never exposes or sends it (unlike, e.g., `loginByAppRole`, which does build a JSON body).

**Customer impact:** London Stock Exchange Group (LSEG) requires this `name` parameter for their Vault deployment and gets `403 permission denied` on an otherwise-valid certificate. This is currently blocking their migration from token-based to certificate-based Vault auth for FCA/PCI-DSS compliance reasons.

## Fix

```
rundeck.storage.provider.1.config.certRoleName=my-certificate-role-name
```

- When `certRoleName` is set: the plugin bypasses the driver's `loginByCert` and issues the login POST directly with body `{"name": "<certRoleName>"}`, reusing the same TLS material / `SSLContext` / shared `HttpClient` the driver already builds.
- When unset: falls through to the existing `vaultAuth.loginByCert(mount)` call — fully backward compatible.

## Changes

- `ConfigOptions.java` — new `VAULT_CERT_ROLE_NAME` constant
- `VaultStoragePlugin.java` — new optional `certRoleName` plugin property
- `VaultClientProvider.java` — new `loginByCertWithRoleName()` helper, wired into the `CERT` auth case
- `README.md` — documented the new property and updated the cert-auth example
- `VaultClientProviderTest.java` — two new tests using an embedded `HttpServer`:
  - asserts the login body is exactly `{"name":"app-01693-lseg-enterprise-rundeck"}` when `certRoleName` is set (LSEG's real example)
  - asserts no body is sent when it's unset (backward-compat)

## Testing

- `./gradlew test` — full suite passes
- New unit tests verify the exact wire-level request body Vault receives

Jira: [RUN-4788](https://pagerduty.atlassian.net/browse/RUN-4788)