### PR TITLE
Fix RUNDECK_GRAILS_URL host mismatch in existing-vault1.x compose file

### DIFF
--- a/test/docker/docker-compose-existing-vault1.x.yml
+++ b/test/docker/docker-compose-existing-vault1.x.yml
@@ -23,7 +23,7 @@ services:
     links:
     - vault
     environment:
-    - RUNDECK_GRAILS_URL=http://localhost:4440
+    - RUNDECK_GRAILS_URL=http://rundeck1:4440
     - RUNDECK_NODE=rundeck1
     - SETUP_TEST_PROJECT=vaulttest
     - RUNDECK_STORAGE_PROVIDER_1_TYPE=vault-storage


### PR DESCRIPTION
## Description

The `existing-vault1.x` functional test scenario was failing on main ([run 32070428854](https://github.com/rundeck-plugins/vault-storage/actions/runs/32070428854/job/95512179488)) with:

```
java.io.IOException: Cross-origin redirect blocked for security: http://localhost:4440/menu/home.
To allow cross-origin redirects set RD_ALLOW_CROSS_ORIGIN_REDIRECT=true or pass --allow-cross-origin-redirect.
```

Root cause: `docker-compose-existing-vault1.x.yml` set `RUNDECK_GRAILS_URL=http://localhost:4440` for the Rundeck server, while the `rd` CLI (installed unpinned via apt, currently `2.2.0`) connects via `RD_URL=http://$RUNDECK_NODE:4440` (i.e. `http://rundeck1:4440`), per `test/docker/dockers/rundeckvault/tests/run.sh`. When the server redirected after login to its configured `localhost` URL, the newer `rd` CLI's cross-origin redirect check (a new default security behavior) rejected it because the host didn't match the request host.

The sibling compose files (`docker-compose-vault.yml`, `docker-compose-existing-vault.yml`) already use `RUNDECK_GRAILS_URL=http://rundeck1:4440`, consistent with the CLI's connection host — this change brings `docker-compose-existing-vault1.x.yml` in line with them.

## Testing instructions

Run the functional test suite locally:

```
./gradlew build && bash run-docker-vault-tests.sh
```

Confirm `test-existing-vault1.x.sh` completes without the `Cross-origin redirect blocked` error and `rd projects create` succeeds.
